### PR TITLE
Fix compilation without deprecated OpenSSL 1.1 APIs

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -535,7 +535,7 @@ AC_ARG_WITH(openssl,
 	    [LIBS="$LIBS -lssl -lcrypto"
 	    AC_MSG_CHECKING(for openssl libraries -lssl and -lcrypto)
 	    AC_TRY_LINK([#include <openssl/ssl.h>
-		],[SSL_library_init()],
+		],[SSL_CTX_new(NULL)],
 		[AC_MSG_RESULT(yes)
 		cons_with_openssl="YES"
 		AC_DEFINE(HAVE_OPENSSL)

--- a/conserver/cutil.c
+++ b/conserver/cutil.c
@@ -57,7 +57,9 @@ Bye(int status)
 {
     DestroyDataStructures();
 #if HAVE_OPENSSL
+# if OPENSSL_VERSION_NUMBER < 0x10100000L
     ERR_free_strings();
+# endif
 #endif
     exit(status);
 }


### PR DESCRIPTION
Builds fine. configure also needs updating. More like removal actually.