### PR TITLE
FreeBSD/FreeBSD GSSAPI Fixes

### DIFF
--- a/conserver/consent.c
+++ b/conserver/consent.c
@@ -700,6 +700,10 @@ ConsState(CONSENT *pCE)
 	case INSSLSHUTDOWN:
 	    return "SSL_shutdown";
 #endif
+#if HAVE_GSSAPI
+	case INGSSACCEPT:
+	    return "GSSAPI_accept";
+#endif
 	case ISFLUSHING:
 	    return "flushing";
     }

--- a/conserver/cutil.c
+++ b/conserver/cutil.c
@@ -1941,7 +1941,11 @@ ProbeInterfaces(in_addr_t bindAddr)
 	if ((ifc.ifc_len - r) < sizeof(*ifr))
 	    break;
 #  ifdef HAVE_SA_LEN
+#  ifdef __FreeBSD__
+	if (sa->sa_len > sizeof(ifr->ifr_addr))
+#  else
 	if (sa->sa_len > sizeof(ifr->ifr_ifru))
+#  endif
 	    r += sizeof(ifr->ifr_name) + sa->sa_len;
 	else
 #  endif

--- a/conserver/group.c
+++ b/conserver/group.c
@@ -66,6 +66,7 @@
 #include <master.h>
 #include <main.h>
 #include <version.h>
+#include <stdio.h>
 
 #if HAVE_PAM
 # include <security/pam_appl.h>
@@ -1985,7 +1986,7 @@ AttemptGSSAPI(CONSCLIENT *pCL)
 	    FileWrite(pCL->fd, FLAGFALSE, sendtok.value, sendtok.length);
 	    FileSetQuoteIAC(pCL->fd, FLAGTRUE);
 	    pCL->iState = S_NORMAL;
-	    gss_release_buffer(NULL, &sendtok);
+	    gss_release_buffer(&stmin, &sendtok);
 	    BuildString((char *)0, pCL->username);
 	    BuildString((char *)0, pCL->acid);
 	    stmaj = gss_display_name(&stmin, user, &dbuf, NULL);
@@ -1995,7 +1996,7 @@ AttemptGSSAPI(CONSCLIENT *pCL)
 	    BuildStringChar('@', pCL->acid);
 	    BuildString(pCL->peername->string, pCL->acid);
 	    gss_release_name(&stmin, &user);
-	    gss_release_buffer(NULL, &dbuf);
+	    gss_release_buffer(&stmin, &dbuf);
 	    ret = 1;
 	    break;
 	case GSS_S_CREDENTIALS_EXPIRED:


### PR DESCRIPTION
- Improve GSSAPI handling under FreeBSD
- Use ifr->ifr_addr instead of ifr->ifr_ifru under FreeBSD