### PR TITLE
fix host consoles in combination --with-ipv6

### DIFF
--- a/conserver/consent.c
+++ b/conserver/consent.c
@@ -931,10 +931,11 @@ ConsInit(CONSENT *pCE)
 # endif
 			if (!SetFlags(cofile, O_NONBLOCK, 0))
 			    goto fail;
-			if ((ret =
-			     connect(cofile, rp->ai_addr,
-				     rp->ai_addrlen)) == 0)
-			    goto success;
+
+			ret = connect(cofile, rp->ai_addr, rp->ai_addrlen);
+			if (ret == 0 || errno == EINPROGRESS)
+				goto success;
+
 		      fail:
 			close(cofile);
 		    }


### PR DESCRIPTION
With a non-blocking socket, `connect(2)` will set `errno` to `EINPROGRESS` and the user must then fetch the success/fail status from the socket.

This was correctly handled in the IPv4 path, but not in the IPv6 path.
