### PR TITLE
Updated conserver/cutil.c and conserver/group.c to use snprintf( ) vi…

### DIFF
--- a/conserver/cutil.c
+++ b/conserver/cutil.c
@@ -618,19 +618,19 @@ FileOpenFD(int fd, enum consFileType type)
 #if DEBUG_CONSFILE_IO
     {
 	char buf[1024];
-	snprintf(buf, 1024, "CONSFILE-%s-%lu-%d.w", progname,
+	snprintf(buf, sizeof(buf), "CONSFILE-%s-%lu-%d.w", progname,
 		(unsigned long)thepid, fd);
 	if ((cfp->debugwfd =
 	     open(buf, O_WRONLY | O_CREAT | O_APPEND, 0644)) != -1) {
-	    snprintf(buf, 1024, "[---- STARTED - %s ----]\n",
+	    snprintf(buf, sizeof(buf), "[---- STARTED - %s ----]\n",
 		    StrTime((time_t *)0));
 	    write(cfp->debugwfd, buf, strlen(buf));
 	}
-	snprintf(buf, 1024, "CONSFILE-%s-%lu-%d.r", progname,
+	snprintf(buf, sizeof(buf), "CONSFILE-%s-%lu-%d.r", progname,
 		(unsigned long)thepid, fd);
 	if ((cfp->debugrfd =
 	     open(buf, O_WRONLY | O_CREAT | O_APPEND, 0644)) != -1) {
-	    snprintf(buf, 1024, "[---- STARTED - %s ----]\n",
+	    snprintf(buf, sizeof(buf), "[---- STARTED - %s ----]\n",
 		    StrTime((time_t *)0));
 	    write(cfp->debugrfd, buf, strlen(buf));
 	}
@@ -663,19 +663,19 @@ FileOpenPipe(int fd, int fdout)
 #if DEBUG_CONSFILE_IO
     {
 	char buf[1024];
-	snprintf(buf, 1024, "CONSFILE-%s-%lu-%d.w", progname,
+	snprintf(buf, sizeof(buf), "CONSFILE-%s-%lu-%d.w", progname,
 		(unsigned long)thepid, fdout);
 	if ((cfp->debugwfd =
 	     open(buf, O_WRONLY | O_CREAT | O_APPEND, 0644)) != -1) {
-	    snprintf(buf, 1024, "[---- STARTED - %s ----]\n",
+	    snprintf(buf, sizeof(buf), "[---- STARTED - %s ----]\n",
 		    StrTime((time_t *)0));
 	    write(cfp->debugwfd, buf, strlen(buf));
 	}
-	snprintf(buf, 1024, "CONSFILE-%s-%lu-%d.r", progname,
+	snprintf(buf, sizeof(buf), "CONSFILE-%s-%lu-%d.r", progname,
 		(unsigned long)thepid, fd);
 	if ((cfp->debugrfd =
 	     open(buf, O_WRONLY | O_CREAT | O_APPEND, 0644)) != -1) {
-	    snprintf(buf, 1024, "[---- STARTED - %s ----]\n",
+	    snprintf(buf, sizeof(buf), "[---- STARTED - %s ----]\n",
 		    StrTime((time_t *)0));
 	    write(cfp->debugrfd, buf, strlen(buf));
 	}
@@ -754,19 +754,19 @@ FileOpen(const char *path, int flag, int mode)
 #if DEBUG_CONSFILE_IO
     {
 	char buf[1024];
-	snprintf(buf, 1024, "CONSFILE-%s-%lu-%d.w", progname,
+	snprintf(buf, sizeof(buf), "CONSFILE-%s-%lu-%d.w", progname,
 		(unsigned long)thepid, fd);
 	if ((cfp->debugwfd =
 	     open(buf, O_WRONLY | O_CREAT | O_APPEND, 0644)) != -1) {
-	    snprintf(buf, 1024, "[---- STARTED - %s ----]\n",
+	    snprintf(buf, sizeof(buf), "[---- STARTED - %s ----]\n",
 		    StrTime((time_t *)0));
 	    write(cfp->debugwfd, buf, strlen(buf));
 	}
-	snprintf(buf, 1024, "CONSFILE-%s-%lu-%d.r", progname,
+	snprintf(buf, sizeof(buf), "CONSFILE-%s-%lu-%d.r", progname,
 		(unsigned long)thepid, fd);
 	if ((cfp->debugrfd =
 	     open(buf, O_WRONLY | O_CREAT | O_APPEND, 0644)) != -1) {
-	    snprintf(buf, 1024, "[---- STARTED - %s ----]\n",
+	    snprintf(buf, sizeof(buf), "[---- STARTED - %s ----]\n",
 		    StrTime((time_t *)0));
 	    write(cfp->debugrfd, buf, strlen(buf));
 	}

--- a/conserver/group.c
+++ b/conserver/group.c
@@ -2560,7 +2560,7 @@ TelOpt(int o)
     if (o < sizeof(telopts) / sizeof(char *))
 	return telopts[o];
     else {
-	snprintf(opt, 128, "%d", o);
+	snprintf(opt, sizeof(opt), "%d", o);
 	return opt;
     }
 }


### PR DESCRIPTION
Updated conserver/cutil.c and conserver/group.c to use snprintf( ) vice sprintf( ) to prevent buffer overflows.

This code change should be carefully checked. I am not normally a coder.