### PR TITLE
master.c: Increase buffer size for GSSAPI exchanges

### DIFF
--- a/conserver/group.c
+++ b/conserver/group.c
@@ -3128,7 +3128,6 @@ DoClientRead(GRPENT *pGE, CONSCLIENT *pCLServing)
 		    }
 #endif
 #if HAVE_GSSAPI
-#define MAX_GSSAPI_TOKSIZE 64*1024
 		} else if (pCLServing->iState == S_IDENT &&
 			   strcmp(pcCmd, "gssapi") == 0) {
 		    if (pcArgs == (char *)0) {

--- a/conserver/group.h
+++ b/conserver/group.h
@@ -84,5 +84,6 @@ extern void SendIWaitClientsMsg(CONSENT *, char *);
 extern int AttemptSSL(CONSCLIENT *);
 #endif
 #if HAVE_GSSAPI
+#define MAX_GSSAPI_TOKSIZE 64*1024
 extern int AttemptGSSAPI(CONSCLIENT *);
 #endif

--- a/conserver/master.c
+++ b/conserver/master.c
@@ -475,10 +475,27 @@ DoNormalRead(CONSCLIENT *pCLServing)
 #if HAVE_GSSAPI
 	    } else if (pCLServing->iState == S_IDENT &&
 		       strcmp(pcCmd, "gssapi") == 0) {
-		FileWrite(pCLServing->fd, FLAGFALSE, "ok\r\n", -1);
-		/* Change the I/O mode right away, we'll do the read
-		 * and accept when the select gets back to us */
-		pCLServing->ioState = INGSSACCEPT;
+		if (pcArgs == (char *)0) {
+		    FileWrite(pCLServing->fd, FLAGFALSE,
+			      "gssapi requires argument\r\n", -1);
+		} else {
+		    FileWrite(pCLServing->fd, FLAGFALSE, "ok\r\n", -1);
+		    /* Read the token size but limit it to 64K,
+		     * that's practical limit for GSSAPI krb5 mechanism.
+		     *
+		     * The client connection will be rejected for large
+		     * requests as server will not be able to parse
+		     * incomplete ASN.1 but this is intentional. */
+		    pCLServing->tokenSize = (size_t) strtol(pcArgs, NULL, 10);
+		    if (pCLServing->tokenSize > MAX_GSSAPI_TOKSIZE) {
+			FileWrite(pCLServing->fd, FLAGFALSE,
+				  "gssapi token size too large\r\n", -1);
+			pCLServing->tokenSize = MAX_GSSAPI_TOKSIZE;
+		    }
+		    /* Change the I/O mode right away, we'll do the read
+		     * and accept when the select gets back to us */
+		    pCLServing->ioState = INGSSACCEPT;
+		}
 #endif
 	    } else if (pCLServing->iState == S_IDENT &&
 		       strcmp(pcCmd, "login") == 0) {


### PR DESCRIPTION
commit 8e3b847 ("Increase buffer size for GSSAPI exchanges") did not update the GSSAPI authentication code in master.c.  In my testing, this results in a 'lost connection' immediately upon trying to connect to the console server when GSSAPI authentication is configured.  After applying the logic from the above commit to master.c, GSSAPI authentication works as expected.